### PR TITLE
Add function to check if date is after shift configuration start date

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@statengine/shiftly",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Calculate common public safety shift schedules.",
   "main": "lib/",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -343,6 +343,19 @@ export function WestfieldIN() {
     timeZone: 'US/Eastern',
   });
 }
+export function CarmelIN() {
+  return [new ShiftConfiguration({
+    firstDay: '2019-01-01',
+    pattern: 'abacacbcb',
+    shiftStart: '0800',
+    timeZone: 'US/Eastern',
+  }), new ShiftConfiguration({
+    firstDay: '2018-01-01',
+    pattern: 'abcbcacab',
+    shiftStart: '0800',
+    timeZone: 'US/Eastern',
+  })].sort((a, b) => a.daysFromPatternStart(b.patternStart));
+}
 
 export function NoblesvilleIN() {
   return new ShiftConfiguration({
@@ -391,6 +404,7 @@ export const FirecaresLookup = {
   90552: AdamsCountyCO,
   81508: FishersIN,
   77934: WestfieldIN,
+  76662: CarmelIN,
   90227: NoblesvilleIN,
   88490: MesaAZ,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,11 @@ export class ShiftConfiguration { // eslint-disable-line import/prefer-default-e
     return `${this.pattern.charAt(0)}${reverse(this.pattern.substring(1, this.pattern.length))}`;
   }
 
+  afterShiftStartDate(date) {
+    const incomingDate = this.normalize(date);
+    return (this.daysFromPatternStart(incomingDate) >= 0);
+  }
+
   beforeShiftChange(date) {
     const startDate = this.shiftStartDate;
     return date.hours() < startDate.hours() || (date.hours() === startDate.hours()

--- a/src/index.js
+++ b/src/index.js
@@ -343,6 +343,22 @@ export function WestfieldIN() {
     timeZone: 'US/Eastern',
   });
 }
+export function CiceroIN() {
+  return new ShiftConfiguration({
+    firstDay: '2019-01-01',
+    pattern: 'acababcbc',
+    shiftStart: '0700',
+    timeZone: 'US/Eastern',
+  });
+}
+export function SheridanIN() {
+  return new ShiftConfiguration({
+    firstDay: '2019-01-01',
+    pattern: 'acababcbc',
+    shiftStart: '0700',
+    timeZone: 'US/Eastern',
+  });
+}
 export function CarmelIN() {
   return [new ShiftConfiguration({
     firstDay: '2019-01-01',
@@ -404,6 +420,8 @@ export const FirecaresLookup = {
   90552: AdamsCountyCO,
   81508: FishersIN,
   77934: WestfieldIN,
+  77485: CiceroIN,
+  94967: SheridanIN,
   76662: CarmelIN,
   90227: NoblesvilleIN,
   88490: MesaAZ,

--- a/test/shiftly.js
+++ b/test/shiftly.js
@@ -102,6 +102,15 @@ describe('ShiftConfiguration', () => {
   it('should return correct shift at turnover time', () => {
     (richmond.calculateShift('2017-07-07T08:00:00-0400').should.equal('A'));
   });
+
+  it('should return true for dates and times after shift start date', () => {
+    const testDateAfter = '2016-10-22';
+    const testDateBefore = '2016-10-10';
+    const onDate = '2016-10-18';
+    (richmond.afterShiftStartDate(testDateAfter).should.equal(true));
+    (richmond.afterShiftStartDate(testDateBefore).should.equal(false));
+    (richmond.afterShiftStartDate(onDate).should.equal(true));
+  });
 });
 
 describe('Firecares Lookup', () => {

--- a/test/shiftly.js
+++ b/test/shiftly.js
@@ -32,6 +32,7 @@ import { ShiftConfiguration,
   AdamsCountyCO,
   FishersIN,
   WestfieldIN,
+  CarmelIN,
   NoblesvilleIN,
   MesaAZ,
 } from '../src';
@@ -63,6 +64,7 @@ const southernPlatteMO = SouthernPlatteMO();
 const adamsCountyCO = AdamsCountyCO();
 const fishersIN = FishersIN();
 const westfieldIN = WestfieldIN();
+const carmelIN = CarmelIN();
 const noblesvilleIN = NoblesvilleIN();
 const mesa = MesaAZ();
 
@@ -140,6 +142,8 @@ describe('Firecares Lookup', () => {
     FirecaresLookup['95671'].should.equal(SouthernPlatteMO);
     FirecaresLookup['90552'].should.equal(AdamsCountyCO);
     FirecaresLookup['81508'].should.equal(FishersIN);
+    FirecaresLookup['77934'].should.equal(WestfieldIN);
+    FirecaresLookup['76662'].should.equal(CarmelIN);
     FirecaresLookup['90227'].should.equal(NoblesvilleIN);
   });
 });
@@ -669,6 +673,41 @@ describe('Westfield, IN', () => {
     tests.forEach((test) => {
       (westfieldIN.calculateShift(test[0])).should.equal(test[1]);
       (westfieldIN.beforeShiftChange(westfieldIN.normalize(test[0]))).should.equal(test[2]);
+    });
+  });
+});
+
+describe('Carmel, IN', () => {
+  it('should match Carmel, IN known shifts', () => {
+    const tests = [
+      ['2019-01-02T08:40:00-0500', 'B', false],
+      ['2019-01-03T08:40:00-0500', 'A', false],
+      ['2019-01-04T08:40:00-0500', 'C', false],
+      ['2019-02-01T08:40:00-0500', 'A', false],
+      ['2019-02-06T08:40:00-0500', 'A', false],
+      ['2018-02-07T08:40:00-0500', 'B', false],
+      ['2018-02-16T08:40:00-0500', 'B', false],
+      ['2018-01-08T07:20:00-0500', 'C', true],
+    ];
+    tests.forEach((test) => {
+      let shiftConfig = carmelIN;
+      if (Array.isArray(shiftConfig)) {
+        // Shift configurations are ordered from latest to oldest.
+        // first config that incoming date is after is configuration to use.
+        let i;
+        for (i = 0; i < shiftConfig.length; i += 1) {
+          if (shiftConfig[i].afterShiftStartDate(test[0])) {
+            shiftConfig = shiftConfig[i];
+            break;
+          }
+        }
+        // We went through above without finding a valid config
+        if (i >= shiftConfig.length) {
+          return null;
+        }
+      }
+      (shiftConfig.calculateShift(test[0])).should.equal(test[1]);
+      (shiftConfig.beforeShiftChange(shiftConfig.normalize(test[0]))).should.equal(test[2]);
     });
   });
 });

--- a/test/shiftly.js
+++ b/test/shiftly.js
@@ -32,6 +32,8 @@ import { ShiftConfiguration,
   AdamsCountyCO,
   FishersIN,
   WestfieldIN,
+  CiceroIN,
+  SheridanIN,
   CarmelIN,
   NoblesvilleIN,
   MesaAZ,
@@ -64,6 +66,8 @@ const southernPlatteMO = SouthernPlatteMO();
 const adamsCountyCO = AdamsCountyCO();
 const fishersIN = FishersIN();
 const westfieldIN = WestfieldIN();
+const ciceroIN = CiceroIN();
+const sheridanIN = SheridanIN();
 const carmelIN = CarmelIN();
 const noblesvilleIN = NoblesvilleIN();
 const mesa = MesaAZ();
@@ -143,6 +147,8 @@ describe('Firecares Lookup', () => {
     FirecaresLookup['90552'].should.equal(AdamsCountyCO);
     FirecaresLookup['81508'].should.equal(FishersIN);
     FirecaresLookup['77934'].should.equal(WestfieldIN);
+    FirecaresLookup['77485'].should.equal(CiceroIN);
+    FirecaresLookup['94967'].should.equal(SheridanIN);
     FirecaresLookup['76662'].should.equal(CarmelIN);
     FirecaresLookup['90227'].should.equal(NoblesvilleIN);
   });
@@ -673,6 +679,44 @@ describe('Westfield, IN', () => {
     tests.forEach((test) => {
       (westfieldIN.calculateShift(test[0])).should.equal(test[1]);
       (westfieldIN.beforeShiftChange(westfieldIN.normalize(test[0]))).should.equal(test[2]);
+    });
+  });
+});
+
+describe('Cicero, IN', () => {
+  it('should match Cicero, IN known shifts', () => {
+    const tests = [
+      ['2019-01-02T08:10:00-0500', 'C', false],
+      ['2019-01-03T08:10:00-0500', 'A', false],
+      ['2019-01-04T08:10:00-0500', 'B', false],
+      ['2019-01-05T08:10:00-0500', 'A', false],
+      ['2019-01-06T08:10:00-0500', 'B', false],
+      ['2019-01-07T08:10:00-0500', 'C', false],
+      ['2019-01-16T08:10:00-0500', 'C', false],
+      ['2019-01-08T05:10:00-0500', 'C', true],
+    ];
+    tests.forEach((test) => {
+      (ciceroIN.calculateShift(test[0])).should.equal(test[1]);
+      (ciceroIN.beforeShiftChange(ciceroIN.normalize(test[0]))).should.equal(test[2]);
+    });
+  });
+});
+
+describe('Sheridan, IN', () => {
+  it('should match Sheridan, IN known shifts', () => {
+    const tests = [
+      ['2019-01-02T08:10:00-0500', 'C', false],
+      ['2019-01-03T08:10:00-0500', 'A', false],
+      ['2019-01-04T08:10:00-0500', 'B', false],
+      ['2019-01-05T08:10:00-0500', 'A', false],
+      ['2019-01-06T08:10:00-0500', 'B', false],
+      ['2019-01-07T08:10:00-0500', 'C', false],
+      ['2019-01-16T08:10:00-0500', 'C', false],
+      ['2019-01-08T05:10:00-0500', 'C', true],
+    ];
+    tests.forEach((test) => {
+      (sheridanIN.calculateShift(test[0])).should.equal(test[1]);
+      (sheridanIN.beforeShiftChange(sheridanIN.normalize(test[0]))).should.equal(test[2]);
     });
   });
 });


### PR DESCRIPTION
This is to aid in supporting multiple shift configs in normalizers. Basic idea is to order shift configurations in normalizers from latest to oldest configuration. Then when calculating shift from normalizer logic, if there are multiple configs, we test the date against each in oder. First shift configuration that the date is after is the configuration to use.